### PR TITLE
Fixed Online Leaderboard

### DIFF
--- a/Assets/Scenes/Menu.unity
+++ b/Assets/Scenes/Menu.unity
@@ -6461,6 +6461,7 @@ GameObject:
   - component: {fileID: 2101621725}
   - component: {fileID: 2101621724}
   - component: {fileID: 2101621726}
+  - component: {fileID: 2101621727}
   m_Layer: 0
   m_Name: ScoreManager
   m_TagString: Untagged
@@ -6508,6 +6509,18 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   rowPrefab: {fileID: 1914671912645132756, guid: 737d59efadd88d74d959830986b87eec, type: 3}
   rowsParent: {fileID: 811719580}
+--- !u!114 &2101621727
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2101621723}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 060887684411c1341a7db02115106feb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &2103432029
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/MenuUIHandler.cs
+++ b/Assets/Scripts/MenuUIHandler.cs
@@ -82,7 +82,8 @@ public class MenuUIHandler : MonoBehaviour
     public void Score()
     {
         ToggleScreen(highScoreScreen);
-        ScoreManager.Instance.DownloadHighScore();
+        if (highScoreScreen.activeInHierarchy)
+            ScoreManager.Instance.DownloadHighScore();
     }
     public void Settings() => ToggleScreen(settingsScreen);
     public void HowToPlay() => ToggleScreen(howToPlayScreen);

--- a/Assets/Scripts/PlayFabManager.cs
+++ b/Assets/Scripts/PlayFabManager.cs
@@ -10,15 +10,29 @@ public class PlayFabManager : MonoBehaviour
     [SerializeField] private GameObject rowPrefab;
     [SerializeField] private Transform rowsParent;
 
+    private PlayerID playerIDManager;
+    private string _customID;
+
+    private void Awake()
+    {
+        playerIDManager = GetComponent<PlayerID>();
+    }
+
     private void Start()
     {
+        if (!playerIDManager.PlayerHasID())
+            playerIDManager.CreatePlayerID();
+
+        _customID = playerIDManager.GetPlayerID();
+        Debug.Log(_customID);
         Login();
+        
     }
     private void Login()
     {
         var request = new LoginWithCustomIDRequest
         {
-            CustomId = SystemInfo.deviceUniqueIdentifier,
+            CustomId = _customID,
             CreateAccount = true,
             InfoRequestParameters = new GetPlayerCombinedInfoRequestParams
             {

--- a/Assets/Scripts/PlayerID.cs
+++ b/Assets/Scripts/PlayerID.cs
@@ -1,0 +1,53 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using UnityEngine;
+
+public class PlayerID : MonoBehaviour
+{
+    private string _playerID;
+
+    public bool PlayerHasID()
+    {
+        string path = Application.persistentDataPath + "/PlayerID.json";
+        if (File.Exists(path))
+        {
+            LoadPlayerID(path);
+            return true;
+        }
+        else
+            return false;
+    }
+    public void CreatePlayerID()
+    {
+        int idNumber;
+        idNumber = Random.Range(0, 999999);
+        _playerID = idNumber.ToString();
+        SavePlayerID();
+    }
+    public string GetPlayerID()
+    {
+        return _playerID;
+    }
+    [System.Serializable]
+    class PlayerIDData
+    {
+        public string PlayerID;
+    }
+    private void SavePlayerID()
+    {
+        PlayerIDData data = new PlayerIDData();
+        data.PlayerID = _playerID;
+
+        string json = JsonUtility.ToJson(data);
+
+        File.WriteAllText(Application.persistentDataPath + "/PlayerID.json", json);
+    }
+    private void LoadPlayerID(string path)
+    {
+        string json = File.ReadAllText(path);
+        PlayerIDData data = JsonUtility.FromJson<PlayerIDData>(json);
+
+        _playerID = data.PlayerID;
+    }
+}

--- a/Assets/Scripts/PlayerID.cs.meta
+++ b/Assets/Scripts/PlayerID.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 060887684411c1341a7db02115106feb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ScoreManager.cs
+++ b/Assets/Scripts/ScoreManager.cs
@@ -44,12 +44,12 @@ public class ScoreManager : MonoBehaviour
 
         string json = JsonUtility.ToJson(data);
 
-        File.WriteAllText(Application.persistentDataPath + "/highscorefile.json", json);
+        File.WriteAllText(Application.persistentDataPath + "/scorefile.json", json);
     }
 
     public void LoadHighScore() // reads highscore data class from a json file
     {
-        string path = Application.persistentDataPath + "/highscorefile.json";
+        string path = Application.persistentDataPath + "/scorefile.json";
         if (File.Exists(path))
         {
             string json = File.ReadAllText(path);


### PR DESCRIPTION
before login sent unique device identifier, which did not work with WebGL

now login sends a customID stored locally client side